### PR TITLE
Add SysEx ID and USB identification, optimize encoder and touch poll

### DIFF
--- a/Arduino/MIDI-Router/MIDI-Router.ino
+++ b/Arduino/MIDI-Router/MIDI-Router.ino
@@ -116,13 +116,14 @@ int led = 13;
 int backLight = 255;
 
 // Knob values
-int oldPosition = 0;
+long oldPosition = 0;
+long newPosition = 0;
 int knobVal = 0;
 int oldKnobVal = 0;
 unsigned long knobTimer = millis();
-unsigned long knobSlowdown = 4;
-int knobSpeedup = 4; // threshold, larger value = less sensitivty to fast turns
-int knobSpeedRate = 4;
+unsigned long knobSlowdown = 2;  // wait this many ms before checking the knob value
+int knobSpeedup = 3; // threshold for difference between old and new value to cause a speed up
+float knobSpeedRate = 2.8; // factor (exponent) to speed up by
 int knobMin = 0;
 int knobMax = 1024;
 

--- a/Arduino/MIDI-Router/MIDI-Router.ino
+++ b/Arduino/MIDI-Router/MIDI-Router.ino
@@ -11,6 +11,8 @@
 #include "SdFat.h"
 #define USE_SDIO 1
 SdFatSdioEX SD;
+File SysCsvFile; // create Sysex CSV object
+#define CSV_DELIM ','
 
 // Knob
 #define EncA 26
@@ -58,6 +60,15 @@ MIDI_CREATE_INSTANCE(HardwareSerial, Serial3, MIDI3);
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial4, MIDI4);
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial5, MIDI5);
 MIDI_CREATE_INSTANCE(HardwareSerial, Serial6, MIDI6);
+
+
+/* todo - can't seem to figure out the right class to reference when making this array of pointers.  
+   Arduino MIDI library is different than the Teensy USB (see below) 
+   
+midi::MidiInterface<HardwareSerial> * dinlist[5] = {
+  &MIDI1, &MIDI2, &MIDI3, &MIDI4, &MIDI5, &MIDI6
+};
+*/
 
 // Create the ports for USB devices plugged into Teensy's 2nd USB port (via hubs)
 USBHost myusb;
@@ -191,6 +202,9 @@ String  outputNames[] = {
   "Comp13", "Comp14", "Comp15", "Comp16", "", "",                 // page 5
   "CV1", "CV2", "CV3", "CV4", "CV5", "CV6"           // page 6
 }; 
+
+// Sysex
+uint8_t sysexIDReq[] = {240, 126, 127, 6, 1, 247};
 
 // Menu options
 int menu = 0;  // which menu are we looking at?  0 = routing, 1 = CV calibration
@@ -337,3 +351,11 @@ bool routing[50][50] = {  // [input port][output port]
   {0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0}
 
 };
+
+// CSV for SD
+char syIdHex[20];
+char mfg[80];
+int16_t idLen;
+int16_t idB1;
+int16_t idB2;
+int16_t idB3;

--- a/Arduino/MIDI-Router/mr0_setup.ino
+++ b/Arduino/MIDI-Router/mr0_setup.ino
@@ -171,6 +171,28 @@ void setup() {
   drawRows();
   drawColumns();
   drawRouting();
+
+  // ============================================================
+  // Sysex CSV stuff
+  // ============================================================
+  
+  if (!SD.chdir("sysexids")) {
+    Serial.println("chdir failed for Folder1.\n");
+  }
+  
+  // Open the file.
+  SysCsvFile = SD.open("sysexids.csv", FILE_WRITE);
+  if (!SysCsvFile) {
+    Serial.println("open failed");
+    return;
+  }
+
+
+
  
+  // sysex id req
+  delay(3000);  // allow send/receive buffers to settle, some MIDI devices are chatty when powered on 
+
+  profileInstruments();
 
 }

--- a/Arduino/MIDI-Router/mr0_sl.ino
+++ b/Arduino/MIDI-Router/mr0_sl.ino
@@ -1,9 +1,10 @@
 void loop() {
 
 
+  routeMidi(); // check incoming MIDi and route it
   readKnob();  // check knob for turn/push
   touchIO();   // process touchscreen input
-  routeMidi(); // check incoming MIDi and route it
+
   
 //**************************
 
@@ -19,4 +20,3 @@ void loop() {
 */
   
 } // end main loop
-

--- a/Arduino/MIDI-Router/mr1_touch.ino
+++ b/Arduino/MIDI-Router/mr1_touch.ino
@@ -74,7 +74,8 @@ void drawMenu_Routing() {
     saveEEPROM();
   } else if (touchY >= tbOY && touchX >= tbOX) {
     // tempo box!
-    drawRows();
+    //drawRows();
+    profileInstruments();
   } else if (touchY <= tbOY && touchX >= tbOX) {
     // input page
     pgIn++;
@@ -289,4 +290,39 @@ boolean withinBox(int x, int y, int bx, int by, int bw, int bh) {
     }
   }
   return 0;
+}
+
+
+// for any given X value of the touch, return the column of our grid
+int getTouchCol(long x){
+  if (x > (WIDE-3) - ((WIDE - cOffset) / columns)) {
+    return(6);
+  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*2) {
+    return(5);
+  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*3) {
+    return(4);
+  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*4) {
+    return(3);
+  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*5) {
+    return(2);
+  } else {
+    return(1);
+  }
+}
+
+// for any given Y value of the touch, return the row of our grid
+int getTouchRow(long y){
+  if (y > (TALL+3) - ((TALL - rOffset) / rows)) {
+    return(6);
+  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*2) {
+    return(5);
+  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*3) {
+    return(4);
+  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*4) {
+    return(3);
+  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*5) {
+    return(2);
+  } else {
+    return(1);
+  }
 }

--- a/Arduino/MIDI-Router/mr5_util.ino
+++ b/Arduino/MIDI-Router/mr5_util.ino
@@ -5,7 +5,6 @@
 // ================================================================================
 
 void matchSysExID(int16_t b1, int16_t b2, int16_t b3) {
-    // Rewind the file for read.
   SysCsvFile.seek(156); // skip first 3 lines of Sysex Table
 
   while (SysCsvFile.available()) {

--- a/Arduino/MIDI-Router/mr5_util.ino
+++ b/Arduino/MIDI-Router/mr5_util.ino
@@ -1,37 +1,157 @@
+// SD card utilities
 
-// for any given X value of the touch, return the column of our grid
-int getTouchCol(long x){
-  if (x > (WIDE-3) - ((WIDE - cOffset) / columns)) {
-    return(6);
-  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*2) {
-    return(5);
-  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*3) {
-    return(4);
-  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*4) {
-    return(3);
-  } else if (x > (WIDE-3) - (((WIDE - cOffset) / columns))*5) {
-    return(2);
-  } else {
-    return(1);
+// ================================================================================
+// SysEx ID lookup
+// ================================================================================
+
+void matchSysExID(int16_t b1, int16_t b2, int16_t b3) {
+    // Rewind the file for read.
+  SysCsvFile.seek(156); // skip first 3 lines of Sysex Table
+
+  while (SysCsvFile.available()) {
+
+    if (csvReadText(&SysCsvFile, syIdHex, sizeof(syIdHex), CSV_DELIM) != CSV_DELIM
+      || csvReadText(&SysCsvFile, mfg, sizeof(mfg), CSV_DELIM) != CSV_DELIM
+      || csvReadInt16(&SysCsvFile, &idLen, CSV_DELIM) != CSV_DELIM
+      || csvReadInt16(&SysCsvFile, &idB1, CSV_DELIM) != CSV_DELIM
+      || csvReadInt16(&SysCsvFile, &idB2, CSV_DELIM) != CSV_DELIM
+      || csvReadInt16(&SysCsvFile, &idB3, CSV_DELIM) != CSV_DELIM) {
+      Serial.println("read error");
+      Serial.print("Pos: "); Serial.println(SysCsvFile.position());
+      int ch;
+      int nr = 0;
+      // print part of file after error.
+      while ((ch = SysCsvFile.read()) > 0 && nr++ < 100) {
+        Serial.write(ch);
+        Serial.print("("); Serial.print(nr);Serial.print(")"); 
+      }
+      break;            
+    }
+    if ( (b1 == 0 && idB1 == 0 && idB2 == b2 && idB3 == b3) 
+      || b1 != 0 && b1 == idB1 ) {
+      printMatch();
+      break;
+    }
+
   }
 }
 
-// for any given Y value of the touch, return the row of our grid
-int getTouchRow(long y){
-  if (y > (TALL+3) - ((TALL - rOffset) / rows)) {
-    return(6);
-  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*2) {
-    return(5);
-  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*3) {
-    return(4);
-  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*4) {
-    return(3);
-  } else if (y > (TALL+3) - (((TALL - rOffset) / rows))*5) {
-    return(2);
-  } else {
-    return(1);
-  }
+void printMatch() {
+  Serial.print("MATCH: ");
+  Serial.print(syIdHex);
+  Serial.print(CSV_DELIM);
+  Serial.print(mfg);
+  Serial.print(CSV_DELIM);
+  Serial.print(idLen);
+  Serial.print(CSV_DELIM);
+  Serial.print(idB1);
+  Serial.print(CSV_DELIM);
+  Serial.print(idB2);
+  Serial.print(CSV_DELIM);
+  Serial.println(idB3);
 }
 
+// ================================================================================
+// CSV
+// ================================================================================
 
 
+int csvReadText(File* SysCsvFile, char* str, size_t size, char delim) {
+  char ch;
+  int rtn;
+  size_t n = 0;
+  while (true) {
+    // check for EOF
+    if (!SysCsvFile->available()) {
+      rtn = 0;
+      break;
+    }
+    if (SysCsvFile->read(&ch, 1) != 1) {
+      // read error
+      rtn = -1;
+      break;
+    }
+    // Delete CR.
+    if (ch == '\r') {
+      continue;
+    }
+    if (ch == delim || ch == '\n') {
+      rtn = ch;
+      break;
+    }
+    if ((n + 1) >= size) {
+      // string too long
+      rtn = -2;
+      n--;
+      break;
+    }
+    str[n++] = ch;
+  }
+  str[n] = '\0';
+  return rtn;
+}
+//------------------------------------------------------------------------------
+int csvReadInt32(File* SysCsvFile, int32_t* num, char delim) {
+  char buf[20];
+  char* ptr;
+  int rtn = csvReadText(SysCsvFile, buf, sizeof(buf), delim);
+  if (rtn < 0) return rtn;
+  *num = strtol(buf, &ptr, 10);
+  if (buf == ptr) return delim;
+  while(isspace(*ptr)) ptr++;
+  return *ptr == 0 ? rtn : -4;
+}
+//------------------------------------------------------------------------------
+int csvReadInt16(File* SysCsvFile, int16_t* num, char delim) {
+  int32_t tmp;
+  int rtn = csvReadInt32(SysCsvFile, &tmp, delim);
+  if (rtn < 0) return rtn;
+  if (tmp < INT_MIN || tmp > INT_MAX) return -5;
+  *num = tmp;
+  if (rtn == 10) return 44; // convert NL to comma
+  return rtn;
+}
+//------------------------------------------------------------------------------
+int csvReadUint32(File* SysCsvFile, uint32_t* num, char delim) {
+  char buf[20];
+  char* ptr;
+  int rtn = csvReadText(SysCsvFile, buf, sizeof(buf), delim);
+  if (rtn < 0) return rtn;
+  *num = strtoul(buf, &ptr, 10);
+  if (buf == ptr) return delim;
+  while(isspace(*ptr)) ptr++;
+  return *ptr == 0 ? rtn : -4;
+}
+//------------------------------------------------------------------------------
+int csvReadUint16(File* SysCsvFile, uint16_t* num, char delim) {
+  uint32_t tmp;
+  int rtn = csvReadUint32(SysCsvFile, &tmp, delim);
+  if (rtn < 0) return rtn;
+  if (tmp > UINT_MAX) return -5;
+  *num = tmp;
+  return rtn;
+}
+//------------------------------------------------------------------------------
+int csvReadDouble(File* SysCsvFile, double* num, char delim) {
+  char buf[20];
+  char* ptr;
+  int rtn = csvReadText(SysCsvFile, buf, sizeof(buf), delim);
+  if (rtn < 0) return rtn;
+  *num = strtod(buf, &ptr);
+  if (buf == ptr) return delim;
+  while(isspace(*ptr)) ptr++;
+  return *ptr == 0 ? rtn : -4;
+}
+//------------------------------------------------------------------------------
+int csvReadFloat(File* SysCsvFile, float* num, char delim) {
+  double tmp;
+  int rtn = csvReadDouble(SysCsvFile, &tmp, delim);
+  if (rtn < 0)return rtn;
+  // could test for too large.
+  *num = tmp;
+  return rtn;
+}
+
+void csvClose() {
+  SysCsvFile.close();
+}

--- a/SD Card/SysExIDs/SysExIDs_old.csv
+++ b/SD Card/SysExIDs/SysExIDs_old.csv
@@ -3,7 +3,7 @@
 60H to 7FH,[Reserved for Other Uses],,,,
 01H,Sequential Circuits,1,1,,
 02H,IDP,1,2,,
-03H,Voyetra Turtle Beach. Inc.,1,3,,
+03H,"Voyetra Turtle Beach, Inc.",1,3,,
 04H,Moog Music,1,4,,
 05H,Passport Designs,1,5,,
 06H,Lexicon Inc.,1,6,,
@@ -13,7 +13,7 @@
 0AH,AKG Acoustics,1,10,,
 0BH,Voyce Music,1,11,,
 0CH,WaveFrame (Timeline),1,12,,
-0DH,ADA Signal Processors. Inc.,1,13,,
+0DH,"ADA Signal Processors, Inc.",1,13,,
 0EH,Garfield Electronics,1,14,,
 0FH,Ensoniq,1,15,,
 10H,Oberheim / Gibson Labs,1,16,,
@@ -71,18 +71,18 @@
 44H,Casio Computer Co. Ltd,1,68,,
 46H,Kamiya Studio Co. Ltd,1,70,,
 47H,Akai Electric Co. Ltd.,1,71,,
-48H,Victor Company of Japan. Ltd.,1,72,,
+48H,"Victor Company of Japan, Ltd.",1,72,,
 4BH,Fujitsu Limited,1,75,,
 4CH,Sony Corporation,1,76,,
 4EH,Teac Corporation,1,78,,
-50H,Matsushita Electric Industrial Co. . Ltd,1,80,,
+50H,"Matsushita Electric Industrial Co. , Ltd",1,80,,
 51H,Fostex Corporation,1,81,,
 52H,Zoom Corporation,1,82,,
-54H,Matsushita Communication Industrial Co.. Ltd.,1,84,,
-55H,Suzuki Musical Instruments MFG. Co.. Ltd.,1,85,,
+54H,"Matsushita Communication Industrial Co., Ltd.",1,84,,
+55H,"Suzuki Musical Instruments MFG. Co., Ltd.",1,85,,
 56H,Fuji Sound Corporation Ltd.,1,86,,
-57H,Acoustic Technical Laboratory. Inc.,1,87,,
-59H,Faith. Inc.,1,89,,
+57H,"Acoustic Technical Laboratory, Inc.",1,87,,
+59H,"Faith, Inc.",1,89,,
 5AH,Internet Corporation,1,90,,
 5CH,Seekers Co. Ltd.,1,92,,
 5FH,SD Card Association,1,95,,
@@ -135,7 +135,7 @@
 00H 00H 2FH,Encore Electronics,3,0,0,47
 00H 00H 30H,Uptown,3,0,0,48
 00H 00H 31H,Voce,3,0,0,49
-00H 00H 32H,CTI Audio. Inc. (Musically Intel. Devs.),3,0,0,50
+00H 00H 32H,"CTI Audio, Inc. (Musically Intel. Devs.)",3,0,0,50
 00H 00H 33H,S3 Incorporated,3,0,0,51
 00H 00H 34H,Broderbund / Red Orb,3,0,0,52
 00H 00H 35H,Allen Organ Co.,3,0,0,53
@@ -148,7 +148,7 @@
 00H 00H 3CH,Hotz Corporation,3,0,0,60
 00H 00H 3DH,ETA Lighting,3,0,0,61
 00H 00H 3EH,NSI Corporation,3,0,0,62
-00H 00H 3FH,Ad Lib. Inc.,3,0,0,63
+00H 00H 3FH,"Ad Lib, Inc.",3,0,0,63
 00H 00H 40H,Richmond Sound Design,3,0,0,64
 00H 00H 41H,Microsoft,3,0,0,65
 00H 00H 42H,Mindscape (Software Toolworks),3,0,0,66
@@ -158,21 +158,21 @@
 00H 00H 46H,White Instruments,3,0,0,70
 00H 00H 47H,GT Electronics/Groove Tubes,3,0,0,71
 00H 00H 48H,Pacific Research & Engineering,3,0,0,72
-00H 00H 49H,Timeline Vista. Inc.,3,0,0,73
+00H 00H 49H,"Timeline Vista, Inc.",3,0,0,73
 00H 00H 4AH,Mesa Boogie Ltd.,3,0,0,74
 00H 00H 4BH,FSLI,3,0,0,75
 00H 00H 4CH,Sequoia Development Group,3,0,0,76
 00H 00H 4DH,Studio Electronics,3,0,0,77
-00H 00H 4EH,Euphonix. Inc,3,0,0,78
-00H 00H 4FH,InterMIDI. Inc.,3,0,0,79
+00H 00H 4EH,"Euphonix, Inc",3,0,0,78
+00H 00H 4FH,"InterMIDI, Inc.",3,0,0,79
 00H 00H 50H,MIDI Solutions Inc.,3,0,0,80
 00H 00H 51H,3DO Company,3,0,0,81
 00H 00H 52H,Lightwave Research / High End Systems,3,0,0,82
 00H 00H 53H,Micro-W Corporation,3,0,0,83
-00H 00H 54H,Spectral Synthesis. Inc.,3,0,0,84
+00H 00H 54H,"Spectral Synthesis, Inc.",3,0,0,84
 00H 00H 55H,Lone Wolf,3,0,0,85
 00H 00H 56H,Studio Technologies Inc.,3,0,0,86
-00H 00H 57H,Peterson Electro-Musical Product. Inc.,3,0,0,87
+00H 00H 57H,"Peterson Electro-Musical Product, Inc.",3,0,0,87
 00H 00H 58H,Atari Corporation,3,0,0,88
 00H 00H 59H,Marion Systems Corporation,3,0,0,89
 00H 00H 5AH,Design Event,3,0,0,90
@@ -212,7 +212,7 @@
 00H 00H 7CH,Media Trix Peripherals,3,0,0,124
 00H 00H 7DH,Brooktree Corp,3,0,0,125
 00H 00H 7EH,Otari Corp,3,0,0,126
-00H 00H 7FH,Key Electronics. Inc.,3,0,0,127
+00H 00H 7FH,"Key Electronics, Inc.",3,0,0,127
 00H 01H 00H,Shure Incorporated,3,0,1,0
 00H 01H 01H,AuraSound,3,0,1,1
 00H 01H 02H,Crystal Semiconductor,3,0,1,2
@@ -273,10 +273,10 @@
 00H 01H 3AH,Sonic Network Inc,3,0,1,58
 00H 01H 3BH,Realtime Music Solutions,3,0,1,59
 00H 01H 3CH,Apogee Digital,3,0,1,60
-00H 01H 3DH,Classical Organs. Inc.,3,0,1,61
+00H 01H 3DH,"Classical Organs, Inc.",3,0,1,61
 00H 01H 3EH,Microtools Inc.,3,0,1,62
 00H 01H 3FH,Numark Industries,3,0,1,63
-00H 01H 40H,Frontier Design Group. LLC,3,0,1,64
+00H 01H 40H,"Frontier Design Group, LLC",3,0,1,64
 00H 01H 41H,Recordare LLC,3,0,1,65
 00H 01H 42H,Starr Labs,3,0,1,66
 00H 01H 43H,Voyager Sound Inc.,3,0,1,67
@@ -298,11 +298,11 @@
 00H 01H 53H,Synthogy,3,0,1,83
 00H 01H 54H,Lynx Studio Technology Inc.,3,0,1,84
 00H 01H 55H,Damage Control Engineering LLC,3,0,1,85
-00H 01H 56H,Yost Engineering. Inc.,3,0,1,86
+00H 01H 56H,"Yost Engineering, Inc.",3,0,1,86
 00H 01H 57H,Brooks & Forsman Designs LLC / DrumLite,3,0,1,87
 00H 01H 58H,Infinite Response,3,0,1,88
 00H 01H 59H,Garritan Corp,3,0,1,89
-00H 01H 5AH,Plogue Art et Technologie. Inc,3,0,1,90
+00H 01H 5AH,"Plogue Art et Technologie, Inc",3,0,1,90
 00H 01H 5BH,RJM Music Technology,3,0,1,91
 00H 01H 5CH,Custom Solutions Software,3,0,1,92
 00H 01H 5DH,Sonarcana LLC / Highly Liquid,3,0,1,93
@@ -311,7 +311,7 @@
 00H 01H 60H,Stanton (Gibson Brands),3,0,1,96
 00H 01H 61H,Livid Instruments,3,0,1,97
 00H 01H 62H,First Act / 745 Media,3,0,1,98
-00H 01H 63H,Pygraphics. Inc.,3,0,1,99
+00H 01H 63H,"Pygraphics, Inc.",3,0,1,99
 00H 01H 64H,Panadigm Innovations Ltd,3,0,1,100
 00H 01H 65H,Avedis Zildjian Co,3,0,1,101
 00H 01H 66H,Auvital Music Corp,3,0,1,102
@@ -383,9 +383,9 @@
 00H 02H 28H ,Neunaber Technology LLC ,3,0,2,40
 00H 02H 29H,Kaom Inc.,3,0,2,41
 00H 02H 2AH,Hallowell EMC,3,0,2,42
-00H 02H 2BH,Sound Devices. LLC,3,0,2,43
-00H 02H 2CH,Spectrasonics. Inc,3,0,2,44
-00H 02H 2DH,Second Sound. LLC,3,0,2,45
+00H 02H 2BH,"Sound Devices, LLC",3,0,2,43
+00H 02H 2CH,"Spectrasonics, Inc",3,0,2,44
+00H 02H 2DH,"Second Sound, LLC",3,0,2,45
 00H 02H 2EH,8eo (Horn),3,0,2,46
 00H 02H 2FH,VIDVOX LLC,3,0,2,47
 00H 02H 30H,Matthews Effects,3,0,2,48
@@ -397,7 +397,7 @@
 00H 20H 05H,Syntec Digital Audio,3,0,32,5
 00H 20H 06H,Trident Audio Developments,3,0,32,6
 00H 20H 07H,Real World Studio,3,0,32,7
-00H 20H 08H,Evolution Synthesis. Ltd,3,0,32,8
+00H 20H 08H,"Evolution Synthesis, Ltd",3,0,32,8
 00H 20H 09H,Yes Technology,3,0,32,9
 00H 20H 0AH,Audiomatica,3,0,32,10
 00H 20H 0BH,Bontempi SpA (Sigma),3,0,32,11


### PR DESCRIPTION
This update adds automatic SysEx ID request/reply functionality to the 6 hardware MIDI ports.  The internal SD card must be updated to match the contents of the SD CARD directory in the repo.

Update also labels USB devices by product ID.

Encoder speed is optimized.

Touchscreen polling optimized to minimize lag issues when changing pages, however it is still an issue.  Need to investigate handling MIDI with an interrupt.